### PR TITLE
cuda-gdb v13.0.85 b1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,2 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-c_stdlib_version:  # [linux]
-  - "2.28"  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,10 +2,8 @@
 {% set version = "13.0.85" %}
 {% set cuda_version = "13.0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64]
 {% set target_name = "x64" %}  # [win]
 {% set extension = "tar.xz" %}  # [not win]
@@ -22,7 +20,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [osx or win or ppc64le]
+  skip: true  # [osx or win]
   skip: true  # [py<38 or py>312]
 
 requirements:
@@ -83,15 +81,16 @@ outputs:
         - cuda-gdbserver --version
     about:
       home: https://developer.nvidia.com/cuda-toolkit
-      dev_url: https://github.com/NVIDIA/cuda-gdb
       license_file: LICENSE
       license: GPL-3.0-only
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: GPL
       summary: CUDA-GDB is the NVIDIA tool for debugging CUDA applications
       description: |
         CUDA-GDB is the NVIDIA tool for debugging CUDA applications running on Linux.
         CUDA-GDB is an extension to the x86-64 port of GDB, the GNU Project debugger.
       doc_url: https://docs.nvidia.com/cuda/cuda-gdb/index.html
+      dev_url: https://github.com/NVIDIA/cuda-gdb
 
   - name: cuda-gdb-src
     files:
@@ -108,27 +107,29 @@ outputs:
         - test -f $PREFIX/extras/cuda-gdb-{{ version }}.src.tar.gz
     about:
       home: https://developer.nvidia.com/cuda-toolkit
-      dev_url: https://github.com/NVIDIA/cuda-gdb
       license_file: LICENSE
       license: GPL-3.0-only
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: GPL
       summary: CUDA-GDB is the NVIDIA tool for debugging CUDA applications
       description: |
         CUDA-GDB is the NVIDIA tool for debugging CUDA applications running on Linux.
         CUDA-GDB is an extension to the x86-64 port of GDB, the GNU Project debugger.
       doc_url: https://docs.nvidia.com/cuda/cuda-gdb/index.html
+      dev_url: https://github.com/NVIDIA/cuda-gdb
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
-  dev_url: https://github.com/NVIDIA/cuda-gdb
   license_file: LICENSE
   license: GPL-3.0-only
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: GPL
   summary: CUDA-GDB is the NVIDIA tool for debugging CUDA applications
   description: |
     CUDA-GDB is the NVIDIA tool for debugging CUDA applications running on Linux.
     CUDA-GDB is an extension to the x86-64 port of GDB, the GNU Project debugger.
   doc_url: https://docs.nvidia.com/cuda/cuda-gdb/index.html
+  dev_url: https://github.com/NVIDIA/cuda-gdb
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-gdb 13.0.85 b1

**Destination channel:** defaults

### Links

- [PKG-12685](https://anaconda.atlassian.net/browse/PKG-12685) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/gdb-feedstock/pull/5

### Explanation of changes:

- Update the binary files included in the package,  see https://github.com/conda-forge/cuda-gdb-feedstock/issues/27
- Based on upstream feedstock's conda-forge/cuda-gdb-feedstock@94f525cf061063e144a4e5a7a7a6909c7de180fd commit (head of `13.0` branch) for CTK 13.0

[PKG-12685]: https://anaconda.atlassian.net/browse/PKG-12685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ